### PR TITLE
fix: Remove duplicate key value in helm chart for kubelink configs

### DIFF
--- a/charts/devtron/values.yaml
+++ b/charts/devtron/values.yaml
@@ -106,7 +106,6 @@ components:
       PG_LOG_QUERY: "true"
       PG_PORT: "5432"
       PG_USER: postgres
-      RUN_HELM_INSTALL_IN_ASYNC_MODE: "false"
     dbconfig:
       secretName: postgresql-postgresql
       keyName: postgresql-password


### PR DESCRIPTION
# Description

Since argocd is not yet on my cluster, I'm trying to bootstrap Devtron using fluxcd v2. It installs on the cluster using regular helm just fine, but fluxcd validates the output in a stricter manner.

It complains of a duplicate key entry for RUN_HELM_INSTALL_IN_ASYNC_MODE.

In the kubelink.configs section values.yaml,  a default for RUN_HELM_INSTALL_IN_ASYNC_MODE  is defined as false. In [templates/kubelink.yam](https://github.com/devtron-labs/devtron/blob/bfa491b25e36c3b5dfb21d3e19f396fbebdcfa46/charts/devtron/templates/kubelink.yaml#L32-L36)l there is a conditional that appends that same key below, meaning in the rendered output it appears twice.

This causes fluxcd to throw the error. [This issue](https://github.com/fluxcd/helm-controller/issues/283) is for a different helm chart, but it is along the same lines.

 # Fixes

Removed the redundant key from kubelink.configs defaults. 
